### PR TITLE
perf: cache masked output to avoid double-scanning history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The entries before 0.4.0 were reconstructed from the Git history and existing ta
 
 ## [Unreleased]
 
+### Changed
+
+- Cache masked message output across requests: each turn now masks only new or changed messages instead of re-scanning the whole conversation twice (context hook + provider-boundary safety net). Cache fills run the full provenance-registering mask; hits require a content fingerprint match and are cleared whenever rules, case sensitivity, masking toggle, or session change. Snapshot persistence and transcript bookkeeping share the same per-message fingerprints to skip unchanged history.
+
+### Added
+
+- Add `tests/perf-mask.bench.ts`, a manual benchmark for the masking hot path (`node tests/perf-mask.bench.ts`).
+
 ## [0.5.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The entries before 0.4.0 were reconstructed from the Git history and existing ta
 
 ## [Unreleased]
 
+### Fixed
+
+- Make masked-output cache lookups match either the original input fingerprint or the stored masked-output fingerprint. The provider boundary re-checks the context hook's already-masked output, so single-hash lookups missed, overwrote the entry, and made the next context pass re-mask unchanged sensitive messages.
+
 ### Changed
 
 - Cache masked message output across requests: each turn now masks only new or changed messages instead of re-scanning the whole conversation twice (context hook + provider-boundary safety net). Cache fills run the full provenance-registering mask; hits require a content fingerprint match and are cleared whenever rules, case sensitivity, masking toggle, or session change. Snapshot persistence and transcript bookkeeping share the same per-message fingerprints to skip unchanged history.

--- a/history-persistence.ts
+++ b/history-persistence.ts
@@ -55,7 +55,7 @@ function isSafePath(path: unknown[]): path is PathPart[] {
   );
 }
 
-function textHash(value: string): string {
+export function textHash(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 

--- a/history-viewer.ts
+++ b/history-viewer.ts
@@ -21,6 +21,9 @@ export interface TranscriptEntry {
   pending?: boolean;
   /** Restored from a session that predates persisted model-input snapshots. */
   snapshotMissing?: boolean;
+  /** Fingerprint of the source message for the stored copies; lets
+   *  mergeTranscript skip re-cloning entries whose content did not change. */
+  hash?: string;
 }
 
 interface HistoryTheme {
@@ -82,6 +85,7 @@ export function mergeTranscript(
   originals: readonly JsonRecord[],
   masked: readonly JsonRecord[],
   capturedAt = Date.now(),
+  hashes?: readonly (string | undefined)[],
 ): TranscriptEntry[] {
   const byKey = new Map(existing.map((entry) => [entry.key, entry]));
   const next = [...existing];
@@ -90,19 +94,29 @@ export function mergeTranscript(
     const original = originals[index]!;
     const maskedMessage = masked[index] ?? original;
     const key = transcriptKey(original, index);
+    const hash = hashes?.[index];
     const prior = byKey.get(key);
     if (prior) {
-      prior.original = cloneMessage(original);
-      prior.masked = cloneMessage(maskedMessage);
-      prior.capturedAt = capturedAt;
+      // Flag transitions apply even when content is unchanged: a pending
+      // assistant response is confirmed by reaching the provider boundary.
       prior.pending = false;
       prior.snapshotMissing = false;
+      prior.capturedAt = capturedAt;
+      // Originals never mutate between requests, so matching fingerprints
+      // mean the stored copies are already identical — skip the two
+      // structuredClone calls. Missing hashes (legacy callers) reclone.
+      if (!hash || prior.hash !== hash) {
+        prior.original = cloneMessage(original);
+        prior.masked = cloneMessage(maskedMessage);
+        prior.hash = hash;
+      }
     } else {
       const entry: TranscriptEntry = {
         key,
         original: cloneMessage(original),
         masked: cloneMessage(maskedMessage),
         capturedAt,
+        hash,
       };
       next.push(entry);
       byKey.set(key, entry);

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,7 @@ import {
   createHistoryViewer,
   mergePendingAssistant,
   mergeTranscript,
+  transcriptKey,
   type TranscriptEntry,
 } from "./history-viewer.ts";
 import {
@@ -90,6 +91,7 @@ import {
   type SessionEntryLike,
   type SnapshotBatch,
 } from "./history-persistence.ts";
+import { MaskedCache, hashMessage } from "./masked-cache.ts";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -108,6 +110,11 @@ const SYSTEM_PROMPT_GUIDANCE =
   "appearance, never transform or derive from them, and note that text " +
   "describing a value's properties (prefix, format, strength) may refer to " +
   "the original value, not the placeholder.]";
+
+// Upper bound for snapshotContentHashes (last-persisted per-message
+// fingerprints). It otherwise mirrors transcript growth, which is unbounded
+// by design; overflowing clears it wholesale, costing one re-diff pass.
+const SNAPSHOT_CONTENT_HASH_MAX_ENTRIES = 10_000;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -213,8 +220,20 @@ export default async function (pi: ExtensionAPI) {
   // A local-only replay of messages that crossed the model boundary.
   let transcript: TranscriptEntry[] = [];
   let snapshotSignatures = new Map<string, string>();
+  /** Last-persisted content fingerprints per messageKey; lets persistSnapshots
+   *  skip buildMessageSnapshot for messages whose original AND masked forms
+   *  are provably unchanged since the previous request. */
+  let snapshotContentHashes = new Map<string, MessageContentHashPair>();
   let requestSequence = 0;
   let sessionStatePersisted = false;
+
+  // Masked-output caches (see masked-cache.ts): history messages are
+  // immutable between turns and masking is deterministic, so unchanged
+  // messages reuse their stored masked form instead of re-running every
+  // rule regex. Cleared by invalidateMaskedCaches() on any masker-input
+  // change (rebuild, toggle, session_start).
+  const maskedCache = new MaskedCache();
+  let systemPromptMemo: { input: string; text: string; count: number } | null = null;
 
   // One-time-per-session warning flags (reset on session_start)
   let fallbackNotifiedThisTurn = false;
@@ -245,10 +264,81 @@ export default async function (pi: ExtensionAPI) {
     return { discover: true };
   }
 
+  /** Cache contents depend on rules, case sensitivity, sessionKey-derived
+   *  placeholders, and provenance behavior; every path that swaps the Masker
+   *  or starts a new session must clear them. Clearing is always safe —
+   *  misses merely refill. */
+  function invalidateMaskedCaches(): void {
+    maskedCache.invalidate();
+    systemPromptMemo = null;
+  }
+
+  interface MessageContentHashPair {
+    original: string;
+    masked: string;
+  }
+
+  interface ResolvedMaskedMessage {
+    masked: unknown;
+    pair: MessageContentHashPair;
+    /** True when served from cache (fill side effects happened earlier). */
+    fromCache: boolean;
+    /** masker-reported replacement count; 0 for cache hits. */
+    count: number;
+  }
+
+  function resolveMaskedMessage(message: unknown, index: number): ResolvedMaskedMessage {
+    const key = message !== null && typeof message === "object"
+      ? transcriptKey(message as Record<string, unknown>, index)
+      : `raw:index:${index}`;
+    const hash = hashMessage(message);
+    const cached = maskedCache.lookup(key, hash);
+    if (cached) {
+      return {
+        masked: cached.masked,
+        pair: { original: hash, masked: cached.maskedHash },
+        fromCache: true,
+        count: 0,
+      };
+    }
+    const role = (message as { role?: string } | null | undefined)?.role;
+    const r = masker.maskValue(message, maskOptionsForRole(role));
+    const maskedHash = hashMessage(r.value);
+    maskedCache.record(key, hash, maskedHash, r.value);
+    return {
+      masked: r.value,
+      pair: { original: hash, masked: maskedHash },
+      fromCache: false,
+      count: r.count,
+    };
+  }
+
+  /**
+   * Mask the system prompt through a one-entry memo. The prompt is static
+   * for a session, yet before_agent_start and before_provider_request each
+   * mask it; the memo stores the pre-guidance text and callers append
+   * options-dependent guidance themselves. Fill runs the full discover:true
+   * mask so provenance registration happens exactly once.
+   */
+  function maskSystemPromptCached(input: string): { text: string; count: number } {
+    if (
+      systemPromptMemo !== null &&
+      systemPromptMemo.input.length === input.length &&
+      systemPromptMemo.input === input
+    ) {
+      return systemPromptMemo;
+    }
+    const r = masker.mask(input, { discover: true });
+    systemPromptMemo = { input, text: r.text, count: r.count };
+    return systemPromptMemo;
+  }
+
   /** Rebuild masker and return any regex-compile warnings for the caller to surface */
   function rebuild(cfg: MaskingConfig): string[] {
     config = cfg;
     masker = buildMasker(cfg.rules);
+    // Rules/caseSensitive changed → cached masked outputs are stale.
+    invalidateMaskedCaches();
     return masker.warnings;
   }
 
@@ -285,19 +375,39 @@ export default async function (pi: ExtensionAPI) {
     updateStatus(ctx);
   }
 
-  /** Persist only new/changed per-message model-input differences. */
+  /** Persist only new/changed per-message model-input differences.
+   *  contentHashes (when provided) skips the full diff/hash walk for
+   *  messages whose original AND masked forms are unchanged since the last
+   *  persisted request — the common case for history on every turn. */
   function persistSnapshots(
     ctx: ExtensionContext,
     originals: Record<string, unknown>[],
     masked: Record<string, unknown>[],
+    contentHashes?: ReadonlyArray<MessageContentHashPair | undefined>,
   ) {
     if (!config.options.persistHistory) return;
     requestSequence++;
     const changed: MessageSnapshot[] = [];
+    const changedPairs: Array<{ key: string; pair?: MessageContentHashPair }> = [];
     for (let index = 0; index < originals.length; index++) {
       const original = originals[index]!;
-      const snapshot = buildMessageSnapshot(original, masked[index] ?? original, index);
-      if (snapshotSignatures.get(snapshot.messageKey) !== snapshot.signature) changed.push(snapshot);
+      const maskedMessage = masked[index] ?? original;
+      const messageKey = transcriptKey(original, index);
+      const pair = contentHashes?.[index];
+      if (pair) {
+        const prev = snapshotContentHashes.get(messageKey);
+        if (
+          prev !== undefined &&
+          snapshotSignatures.has(messageKey) &&
+          prev.original === pair.original &&
+          prev.masked === pair.masked
+        ) continue;
+      }
+      const snapshot = buildMessageSnapshot(original, maskedMessage, index);
+      if (snapshotSignatures.get(snapshot.messageKey) !== snapshot.signature) {
+        changed.push(snapshot);
+        changedPairs.push({ key: snapshot.messageKey, pair });
+      }
     }
     if (changed.length === 0) return;
 
@@ -309,7 +419,12 @@ export default async function (pi: ExtensionAPI) {
     };
     try {
       pi.appendEntry(SNAPSHOT_ENTRY, batch);
-      for (const snapshot of changed) snapshotSignatures.set(snapshot.messageKey, snapshot.signature);
+      if (snapshotContentHashes.size >= SNAPSHOT_CONTENT_HASH_MAX_ENTRIES) snapshotContentHashes.clear();
+      for (let i = 0; i < changed.length; i++) {
+        snapshotSignatures.set(changed[i]!.messageKey, changed[i]!.signature);
+        const recordedPair = changedPairs[i]!.pair;
+        if (recordedPair) snapshotContentHashes.set(changedPairs[i]!.key, recordedPair);
+      }
     } catch (err) {
       if (!persistenceWarned) {
         persistenceWarned = true;
@@ -350,6 +465,11 @@ export default async function (pi: ExtensionAPI) {
     dynamicPlaceholderMap = new Map();
     llmInventedValues = new Set();
     protectedValues = new Set();
+    snapshotContentHashes = new Map();
+    // Fresh sessionKey and provenance sets — cached masked outputs from any
+    // prior state must not survive. (rebuild() below clears again; this also
+    // covers paths that never reach it.)
+    invalidateMaskedCaches();
     fallbackNotifiedThisTurn = false;
     systemPromptWarned = false;
     dynamicMapWarned = false;
@@ -363,11 +483,11 @@ export default async function (pi: ExtensionAPI) {
     const compileWarnings = rebuild(persisted.config);
 
     // Replay the full active branch locally to rebuild dynamic mappings and
-    // first-seen provenance using the restored session key. Nothing from this
-    // pass is counted or sent to the model.
-    for (const message of restored.messages) {
-      const role = typeof message.role === "string" ? message.role : undefined;
-      masker.maskValue(message, maskOptionsForRole(role));
+    // first-seen provenance using the restored session key, priming the
+    // masked-output cache so the first post-restore request skips re-masking
+    // history. Nothing from this pass is counted or sent to the model.
+    for (let index = 0; index < restored.messages.length; index++) {
+      resolveMaskedMessage(restored.messages[index], index);
     }
 
     ensureSessionStatePersisted(ctx);
@@ -400,25 +520,35 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("context", async (event, ctx) => {
     const messages = event.messages;
+    const originals = messages as unknown as Record<string, unknown>[];
     // Retain the complete local replay even while masking is off. When it is
     // enabled, the same entries are replaced below with the actual masked form
     // sent through this boundary.
     if (!config.enabled || config.rules.length === 0) {
-      const originals = messages as unknown as Record<string, unknown>[];
-      transcript = mergeTranscript(
-        transcript,
-        originals,
-        originals,
-      );
-      persistSnapshots(ctx, originals, originals);
+      const disabledHashes: string[] = [];
+      const disabledPairs: MessageContentHashPair[] = [];
+      for (let index = 0; index < originals.length; index++) {
+        const hash = hashMessage(originals[index]);
+        disabledHashes.push(hash);
+        disabledPairs.push({ original: hash, masked: hash });
+      }
+      transcript = mergeTranscript(transcript, originals, originals, Date.now(), disabledHashes);
+      persistSnapshots(ctx, originals, originals, disabledPairs);
       return;
     }
 
     // Mask everything (including history) before returning to the LLM, so
-    // it only ever sees placeholders for protected values.
-    const maskedMessages = messages.map((msg) =>
-      masker.maskValue(msg, maskOptionsForRole((msg as { role?: string }).role)).value
-    );
+    // it only ever sees placeholders for protected values. History messages
+    // are immutable between turns, so resolveMaskedMessage serves their
+    // stored masked form from the cache; the full maskValue cost is paid
+    // only for new or changed tail messages.
+    const maskedMessages: Record<string, unknown>[] = [];
+    const contentHashes: MessageContentHashPair[] = [];
+    for (let index = 0; index < originals.length; index++) {
+      const resolved = resolveMaskedMessage(originals[index], index);
+      maskedMessages.push(resolved.masked as Record<string, unknown>);
+      contentHashes.push(resolved.pair);
+    }
 
     if (!dynamicMapWarned && dynamicPlaceholderMap.size >= DYNAMIC_MAP_WARN_THRESHOLD) {
       dynamicMapWarned = true;
@@ -437,15 +567,13 @@ export default async function (pi: ExtensionAPI) {
 
     transcript = mergeTranscript(
       transcript,
-      messages as unknown as Record<string, unknown>[],
-      maskedMessages as Record<string, unknown>[],
+      originals,
+      maskedMessages,
+      Date.now(),
+      contentHashes.map((pair) => pair.original),
     );
-    persistSnapshots(
-      ctx,
-      messages as unknown as Record<string, unknown>[],
-      maskedMessages as Record<string, unknown>[],
-    );
-    return { messages: maskedMessages as typeof event.messages };
+    persistSnapshots(ctx, originals, maskedMessages, contentHashes);
+    return { messages: maskedMessages as unknown as typeof event.messages };
   });
 
   // ── Hook 2: message_end — inbound unmasking ───────────────────────────────
@@ -502,7 +630,9 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("before_agent_start", async (event, ctx) => {
     if (!config.enabled || config.rules.length === 0) return;
-    const r = masker.mask(event.systemPrompt, { discover: true });
+    // Memoized: the prompt is static per session and is masked again at the
+    // provider boundary; fill registers provenance exactly once.
+    const r = maskSystemPromptCached(event.systemPrompt);
     let text = r.text;
     if (config.options.systemPromptGuidance) {
       text += "\n\n" + SYSTEM_PROMPT_GUIDANCE;
@@ -527,22 +657,29 @@ export default async function (pi: ExtensionAPI) {
 
     const record = payload as Record<string, unknown>;
     let intercepted = 0;
+    let changedCount = 0;
 
     if (Array.isArray(record.messages)) {
-      const masked = record.messages.map((m) => {
+      const source = record.messages as unknown[];
+      const maskedMessages: unknown[] = new Array(source.length);
+      for (let index = 0; index < source.length; index++) {
+        const m = source[index];
+        const resolved = resolveMaskedMessage(m, index);
+        maskedMessages[index] = resolved.masked;
+        // Cache hits mean the context hook already sent this exact content
+        // through the masker — only fills can be boundary interceptions.
+        // Assistant re-masking at this boundary is bookkeeping and never
+        // counts toward the fallback notice.
         const role = (m as { role?: string } | null)?.role;
-        const isAssistant = role === "assistant";
-        const r = masker.maskValue(m, maskOptionsForRole(role));
-        // Assistant re-masking at this boundary is bookkeeping (idempotent
-        // on the context hook's output); only genuinely intercepted
-        // user/tool-side values count toward the fallback notice.
-        if (!isAssistant) intercepted += r.count;
-        return r.value;
-      });
-      record.messages = masked;
+        if (!resolved.fromCache && role !== "assistant") intercepted += resolved.count;
+        if (resolved.masked !== m) changedCount++;
+      }
+      // Replace the payload only when something actually differs; system and
+      // prompt below are still scanned unconditionally either way.
+      if (changedCount > 0) record.messages = maskedMessages;
     }
     if (typeof record.system === "string") {
-      const r = masker.mask(record.system, { discover: true });
+      const r = maskSystemPromptCached(record.system);
       if (r.count > 0) {
         record.system = r.text;
         intercepted += r.count;
@@ -2096,6 +2233,9 @@ export default async function (pi: ExtensionAPI) {
       }
       config = { ...config, enabled };
       masker = buildMasker(enabled ? config.rules : []);
+      // Bypasses rebuild(), so clear the masked-output caches explicitly:
+      // toggling must never serve cached outputs across an enable cycle.
+      invalidateMaskedCaches();
       ctx.ui.notify(`Data masking ${enabled ? "enabled" : "disabled"} (saved for future sessions)`, "info");
       notifyWarnings(ctx, masker.warnings);
       updateStatus(ctx);

--- a/index.ts
+++ b/index.ts
@@ -294,9 +294,13 @@ export default async function (pi: ExtensionAPI) {
     const hash = hashMessage(message);
     const cached = maskedCache.lookup(key, hash);
     if (cached) {
+      // Serve the entry's canonical pair: a hit may have matched via the
+      // stored masked-output hash (provider boundary re-checks the context
+      // hook's output), and pair.original must stay the un-masked
+      // fingerprint either way.
       return {
         masked: cached.masked,
-        pair: { original: hash, masked: cached.maskedHash },
+        pair: { original: cached.hash, masked: cached.maskedHash },
         fromCache: true,
         count: 0,
       };

--- a/masked-cache.ts
+++ b/masked-cache.ts
@@ -15,10 +15,19 @@
  *  - Fill always runs the full masker.maskValue(), so provenance side
  *    effects (shouldMaskSpan registering protected/llmInvented values)
  *    happen exactly once, at fill time. Hits skip only the regex work.
- *  - A hit requires the ORIGINAL content fingerprint to match, so any
- *    mutation of a payload object between hooks is re-masked, never served
- *    stale. Key collisions (e.g. transcriptKey's role:index fallback
- *    shifting after appends) degrade to misses, never false hits.
+ *  - A hit requires a content fingerprint match against EITHER the entry's
+ *    original input hash or its stored masked-output hash. The context hook
+ *    records entries under the original hash, while before_provider_request
+ *    receives the context hook's masked output and looks it up by the masked
+ *    hash — accepting both keeps those alternating views on one entry
+ *    instead of missing and overwriting each other (which would make every
+ *    sensitive message thrash between the two hashes and never hit). A hit
+ *    never replaces the stored original mapping, so the next context(original)
+ *    still resolves. Masking is idempotent over placeholders, so serving an
+ *    entry's masked output for its masked input equals a fresh maskValue run;
+ *    any genuinely different payload under the same key degrades to a miss
+ *    (key collisions like transcriptKey's role:index fallback shifting after
+ *    appends), never a false hit.
  *  - invalidate() must be called whenever masker inputs change: rebuild()
  *    (rules, caseSensitive), /masking-toggle (bypasses rebuild()), and
  *    session_start (fresh sessionKey + provenance sets). Clearing is always
@@ -72,10 +81,18 @@ export class MaskedCache {
     return this.entries.size;
   }
 
-  /** Cached entry for key, but only when the content fingerprint matches. */
+  /**
+   * Cached entry for key when the fingerprint matches the recorded ORIGINAL
+   * hash or the stored masked-output hash. The masked-hash branch serves the
+   * provider boundary (whose input is the context hook's already-masked
+   * output) without touching the entry: the original mapping survives so the
+   * next context(original) lookup still hits.
+   */
   lookup(key: string, hash: string): MaskedCacheEntry | undefined {
     const entry = this.entries.get(key);
-    return entry !== undefined && entry.hash === hash ? entry : undefined;
+    return entry !== undefined && (entry.hash === hash || entry.maskedHash === hash)
+      ? entry
+      : undefined;
   }
 
   record(key: string, hash: string, maskedHash: string, masked: unknown): void {

--- a/masked-cache.ts
+++ b/masked-cache.ts
@@ -1,0 +1,89 @@
+/**
+ * masked-cache.ts
+ * Per-session cache of masked message outputs shared by the outbound hooks.
+ *
+ * Why it exists: the context hook masks the ENTIRE conversation on every
+ * model request and before_provider_request re-masks all of it again as a
+ * safety net. History messages are immutable between turns and masking is
+ * deterministic given (rules, sessionKey, dynamicMap state) — a repeated
+ * mask of the same original resolves every already-seen value through
+ * dynamicMap.get(real), returning pinned placeholders — so a cached masked
+ * output for an unchanged original is byte-identical to a fresh maskValue
+ * run, minus the O(rules × text) regex scans.
+ *
+ * Correctness contract:
+ *  - Fill always runs the full masker.maskValue(), so provenance side
+ *    effects (shouldMaskSpan registering protected/llmInvented values)
+ *    happen exactly once, at fill time. Hits skip only the regex work.
+ *  - A hit requires the ORIGINAL content fingerprint to match, so any
+ *    mutation of a payload object between hooks is re-masked, never served
+ *    stale. Key collisions (e.g. transcriptKey's role:index fallback
+ *    shifting after appends) degrade to misses, never false hits.
+ *  - invalidate() must be called whenever masker inputs change: rebuild()
+ *    (rules, caseSensitive), /masking-toggle (bypasses rebuild()), and
+ *    session_start (fresh sessionKey + provenance sets). Clearing is always
+ *    safe — misses merely refill.
+ */
+
+import { textHash } from "./history-persistence.ts";
+
+/**
+ * Strings longer than this are hashed individually during fingerprinting so
+ * a multi-megabyte base64 image block never becomes part of one giant JSON
+ * concatenation (sha256 still covers its full content).
+ */
+const LONG_STRING_HASH_THRESHOLD = 4096;
+
+/**
+ * Upper bound on cached messages; the map is cleared wholesale on overflow
+ * because refilling an entry costs far less than tracking LRU order.
+ */
+export const MASKED_CACHE_MAX_ENTRIES = 5000;
+
+/** Stable content fingerprint of an arbitrary JSON-serializable message. */
+export function hashMessage(message: unknown): string {
+  return textHash(JSON.stringify(message, (_key, value) =>
+    typeof value === "string" && value.length > LONG_STRING_HASH_THRESHOLD
+      ? `__len:${value.length}:${textHash(value)}`
+      : value
+  ));
+}
+
+export interface MaskedCacheEntry {
+  /** Fingerprint of the un-masked input this entry was produced from. */
+  hash: string;
+  /** Fingerprint of the masked output; lets snapshot persistence skip
+   *  re-diffing messages whose masked form provably did not change. */
+  maskedHash: string;
+  /**
+   * Stored AND served BY REFERENCE: the same object may be handed to many
+   * consecutive requests (context hook return value and provider payload).
+   * Callers must treat it as read-only shared state — fingerprint checks
+   * protect against input-side mutations, not output-side ones. Mutating a
+   * served value would corrupt every future hit for that key.
+   */
+  masked: unknown;
+}
+
+export class MaskedCache {
+  private entries = new Map<string, MaskedCacheEntry>();
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Cached entry for key, but only when the content fingerprint matches. */
+  lookup(key: string, hash: string): MaskedCacheEntry | undefined {
+    const entry = this.entries.get(key);
+    return entry !== undefined && entry.hash === hash ? entry : undefined;
+  }
+
+  record(key: string, hash: string, maskedHash: string, masked: unknown): void {
+    if (this.entries.size >= MASKED_CACHE_MAX_ENTRIES) this.entries.clear();
+    this.entries.set(key, { hash, maskedHash, masked });
+  }
+
+  invalidate(): void {
+    this.entries.clear();
+  }
+}

--- a/tests/masked-cache.integration.test.ts
+++ b/tests/masked-cache.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * tests/masked-cache.integration.test.ts
+ * End-to-end regression for the masked-output cache across the two outbound
+ * hooks: context(original) -> before_provider_request(masked) must not
+ * re-run the masker, and the next turn's context(original) must still hit.
+ * This is the exact sequence from the PR #2 review where single-hash lookups
+ * made sensitive messages thrash between the original and masked hashes.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Masker } from "../masker.ts";
+
+const TEST_AGENT_DIR = mkdtempSync(join(tmpdir(), "masking-cache-agent-"));
+process.env.PI_CODING_AGENT_DIR = TEST_AGENT_DIR;
+process.on("exit", () => rmSync(TEST_AGENT_DIR, { recursive: true, force: true }));
+
+type Handler = (event: unknown, ctx: unknown) => Promise<unknown>;
+
+async function createHarness(cwd: string) {
+  const events = new Map<string, Handler[]>();
+  const pi = {
+    on(name: string, handler: Handler) {
+      const handlers = events.get(name) ?? [];
+      handlers.push(handler);
+      events.set(name, handlers);
+    },
+    registerCommand() {},
+    appendEntry() {},
+  };
+  const ctx = {
+    cwd,
+    ui: { notify() {}, setStatus() {}, setWidget() {} },
+    sessionManager: { getBranch: () => [] },
+  };
+
+  const extension = (await import("../index.ts")).default;
+  await extension(pi as never);
+  for (const handler of events.get("session_start") ?? []) await handler({}, ctx);
+
+  return {
+    ctx,
+    async emit(name: string, event: unknown): Promise<unknown> {
+      let result: unknown;
+      for (const handler of events.get(name) ?? []) result = await handler(event, ctx);
+      return result;
+    },
+    async shutdown() {
+      for (const handler of events.get("session_shutdown") ?? []) await handler({}, ctx);
+    },
+  };
+}
+
+/** Count masker.maskValue invocations to observe when masking actually runs. */
+function spyOnMaskValue() {
+  const original = Masker.prototype.maskValue;
+  let calls = 0;
+  Masker.prototype.maskValue = function (value: unknown, opts?: Parameters<typeof original>[1]) {
+    calls++;
+    return original.call(this, value, opts);
+  };
+  return {
+    calls: () => calls,
+    restore: () => {
+      Masker.prototype.maskValue = original;
+    },
+  };
+}
+
+test("context(original) -> provider(masked) -> next context(original) invokes masking only once", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "masking-cache-"));
+  const configDir = join(dir, ".pi", "pi-data-masking");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "masking.config.json"), JSON.stringify({
+    rules: [{ id: "email", name: "Corp email", real: "alice@corp.com", placeholder: "bob@corp.com" }],
+  }));
+
+  const harness = await createHarness(dir);
+  const history = [
+    { role: "user", content: [{ type: "text", text: "mail alice@corp.com please" }] },
+    { role: "assistant", content: [{ type: "text", text: "done" }] },
+  ];
+
+  try {
+    const first = await harness.emit("context", { messages: structuredClone(history) }) as {
+      messages: Array<{ role: string; content: Array<{ text: string }> }>;
+    };
+    assert.equal(first.messages[0]!.role, "user");
+    assert.equal(first.messages[0]!.content[0]!.text.includes("alice@corp.com"), false, "original must be masked");
+    assert.ok(first.messages[0]!.content[0]!.text.includes("bob@corp.com"), "placeholder must be present");
+
+    const spy = spyOnMaskValue();
+    try {
+      // The provider boundary receives exactly what the context hook produced:
+      // every message fingerprint now matches the stored masked-output hash.
+      const payload: Record<string, unknown> = { messages: first.messages };
+      await harness.emit("before_provider_request", { payload });
+      assert.equal(spy.calls(), 0, "provider(masked) must be served from cache without re-masking");
+      assert.equal(payload.messages, first.messages, "unchanged payload messages must not be replaced");
+
+      // Next turn: the same history reaches the context hook again. The
+      // masked-boundary pass above must not have replaced the original
+      // mapping, so this lookup hits too.
+      const second = await harness.emit("context", { messages: structuredClone(history) }) as {
+        messages: Array<{ role: string; content: Array<{ text: string }> }>;
+      };
+      assert.equal(spy.calls(), 0, "next context(original) must be served from cache without re-masking");
+      assert.deepEqual(JSON.parse(JSON.stringify(second)), JSON.parse(JSON.stringify(first)));
+    } finally {
+      spy.restore();
+    }
+  } finally {
+    await harness.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/masked-cache.test.ts
+++ b/tests/masked-cache.test.ts
@@ -1,0 +1,144 @@
+/**
+ * tests/masked-cache.test.ts
+ * Tests for the masked-output cache primitives shared by the outbound hooks:
+ * fingerprinting, hit/miss/invalidate semantics, capacity handling, the
+ * mergeTranscript clone-skip, and masker determinism while the dynamic map
+ * grows (the property that makes cross-turn caching sound).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MASKED_CACHE_MAX_ENTRIES, MaskedCache, hashMessage } from "../masked-cache.ts";
+import { Masker } from "../masker.ts";
+import type { MaskingRule } from "../masker.ts";
+import { mergePendingAssistant, mergeTranscript, transcriptKey } from "../history-viewer.ts";
+
+const KEY = Buffer.from("0123456789abcdef0123456789abcdef", "hex");
+
+test("hashMessage is stable per content and sensitive to changes", () => {
+  const message = { role: "user", content: "call 555-1234" };
+  assert.equal(hashMessage(message), hashMessage({ role: "user", content: "call 555-1234" }));
+  assert.notEqual(hashMessage(message), hashMessage({ role: "user", content: "call 555-1235" }));
+});
+
+test("long strings are hashed by content without joining into one giant JSON string", () => {
+  const longA = "a".repeat(10_000);
+  const longB = "a".repeat(9_999) + "b";
+  assert.equal(hashMessage({ data: longA }), hashMessage({ data: longA }));
+  assert.notEqual(hashMessage({ data: longA }), hashMessage({ data: longB }));
+});
+
+test("cache serves hits only when the content fingerprint matches", () => {
+  const cache = new MaskedCache();
+  cache.record("user:index:3", "hash-a", "mask-a", { content: "masked A" });
+
+  const hit = cache.lookup("user:index:3", "hash-a");
+  assert.ok(hit);
+  assert.deepEqual(hit.masked, { content: "masked A" });
+  assert.equal(hit.maskedHash, "mask-a");
+
+  // Key reuse with different content (transcriptKey index fallback shifting
+  // after appends) must degrade to a miss, never a stale hit.
+  assert.equal(cache.lookup("user:index:3", "hash-b"), undefined);
+  assert.equal(cache.lookup("tool:other", "hash-a"), undefined);
+});
+
+test("cache clears wholesale at capacity instead of tracking LRU order", () => {
+  const cache = new MaskedCache();
+  for (let index = 0; index < MASKED_CACHE_MAX_ENTRIES; index++) {
+    cache.record(`key-${index}`, "h", "m", index);
+  }
+  assert.equal(cache.size, MASKED_CACHE_MAX_ENTRIES);
+
+  cache.record("fresh", "h", "m", "fresh");
+  assert.equal(cache.size, 1);
+  assert.ok(cache.lookup("fresh", "h"));
+  assert.equal(cache.lookup("key-0", "h"), undefined);
+});
+
+test("invalidate empties the cache", () => {
+  const cache = new MaskedCache();
+  cache.record("k", "h", "m", 1);
+  cache.invalidate();
+  assert.equal(cache.size, 0);
+  assert.equal(cache.lookup("k", "h"), undefined);
+});
+
+test("masking stays deterministic while the dynamic map and provenance sets grow", () => {
+  // The property that justifies caching across turns: a fresh mask of an
+  // unchanged original resolves already-seen values through dynamicMap.get,
+  // so later growth of the map/sets cannot change its output.
+  const dynamicMap = new Map();
+  const llmInventedValues = new Set<string>();
+  const protectedValues = new Set<string>();
+  const rules: MaskingRule[] = [{ id: "phone", type: "regex", pattern: "\\d{3}-\\d{4}" }];
+  const masker = new Masker(rules, true, KEY, dynamicMap, llmInventedValues, protectedValues);
+
+  const historyMessage = { role: "user", content: "call 555-1234 now" };
+  const first = masker.maskValue(historyMessage, { discover: true });
+
+  for (let index = 0; index < 50; index++) {
+    masker.maskValue(
+      { role: "user", content: `num ${String(index).padStart(3, "0")}-${String(7000 + index).padStart(4, "0")}` },
+      { discover: true },
+    );
+  }
+  assert.equal(dynamicMap.size, 51);
+
+  const second = masker.maskValue(historyMessage, { discover: true });
+  assert.deepEqual(second.value, first.value);
+  assert.equal(second.count, first.count);
+});
+
+test("mergeTranscript skips cloning entries whose content hash is unchanged", () => {
+  const message = { role: "user", timestamp: 1, content: "secret" };
+  const first = mergeTranscript([], [message], [{ ...message, content: "[MASKED]" }], 10, ["hash-1"]);
+  const entry = first[0]!;
+
+  const second = mergeTranscript(first, [message], [{ ...message, content: "[MASKED]" }], 20, ["hash-1"]);
+  assert.equal(second.length, 1);
+  assert.ok(second[0] === entry);
+  assert.ok(second[0]!.original === entry.original);
+  assert.ok(second[0]!.masked === entry.masked);
+  assert.equal(second[0]!.capturedAt, 20);
+});
+
+test("mergeTranscript re-clones when the hash changes", () => {
+  const message = { role: "user", timestamp: 1, content: "secret" };
+  const first = mergeTranscript([], [message], [{ ...message, content: "[MASKED]" }], 10, ["hash-1"]);
+  const entry = first[0]!;
+  const staleMasked = entry.masked;
+  const staleOriginal = entry.original;
+
+  const second = mergeTranscript(first, [message], [{ ...message, content: "[REMASKED]" }], 20, ["hash-2"]);
+  assert.equal(second.length, 1);
+  assert.ok(second[0] === entry); // entry object is reused…
+  assert.ok(second[0]!.masked !== staleMasked); // …but the stored copies are fresh
+  assert.ok(second[0]!.original !== staleOriginal);
+  assert.equal(second[0]!.masked.content, "[REMASKED]");
+  assert.equal(second[0]!.hash, "hash-2");
+});
+
+test("unchanged-hash merge still confirms pending assistant responses", () => {
+  const message = { role: "assistant", timestamp: 2, content: [{ type: "text", text: "hi" }] };
+  const pending = mergePendingAssistant([], message, message, 5);
+  pending[0]!.hash = "hash-pending";
+
+  const confirmed = mergeTranscript(pending, [message], [message], 9, ["hash-pending"]);
+  assert.equal(confirmed.length, 1);
+  assert.equal(confirmed[0]!.pending, false);
+  assert.ok(confirmed[0]!.original === pending[0]!.original);
+});
+
+test("legacy callers without hashes keep updating entries in place", () => {
+  const original = { role: "user", timestamp: 1, content: "secret" };
+  const first = mergeTranscript([], [original], [original], 10);
+  const second = mergeTranscript(first, [original], [{ ...original, content: "[MASKED]" }], 20);
+  assert.equal(second[0]!.masked.content, "[MASKED]");
+  assert.equal(second[0]!.capturedAt, 20);
+});
+
+test("transcriptKey is stable for timestamped messages regardless of index", () => {
+  const message = { role: "user", timestamp: 42, content: "x" };
+  assert.equal(transcriptKey(message, 0), transcriptKey(message, 7));
+});

--- a/tests/masked-cache.test.ts
+++ b/tests/masked-cache.test.ts
@@ -43,6 +43,33 @@ test("cache serves hits only when the content fingerprint matches", () => {
   assert.equal(cache.lookup("tool:other", "hash-a"), undefined);
 });
 
+test("masked-output hash is also a hit and never replaces the original mapping", () => {
+  // Regression for PR #2 review: the context hook records entries under the
+  // original hash, but before_provider_request receives the context hook's
+  // masked output and looks it up by the masked hash. If only the original
+  // hash matched, that lookup missed, overwrote the entry under the masked
+  // hash, and made the next context(original) miss again — sensitive
+  // messages thrashed between the two hashes and never hit.
+  const cache = new MaskedCache();
+  const masked = { role: "user", content: "call [PHONE_1]" };
+  cache.record("user:index:0", "hash-original", "hash-masked", masked);
+
+  // provider(masked): hits via the stored masked-output hash…
+  const viaMasked = cache.lookup("user:index:0", "hash-masked");
+  assert.ok(viaMasked);
+  assert.ok(viaMasked === cache.lookup("user:index:0", "hash-original"));
+  assert.equal(viaMasked!.masked, masked);
+  assert.equal(viaMasked!.hash, "hash-original");
+
+  // …without replacing the entry, so the next context(original) still hits.
+  const nextContext = cache.lookup("user:index:0", "hash-original");
+  assert.ok(nextContext);
+  assert.equal(nextContext!.masked, masked);
+
+  // An unrelated fingerprint under the same key still misses.
+  assert.equal(cache.lookup("user:index:0", "hash-other"), undefined);
+});
+
 test("cache clears wholesale at capacity instead of tracking LRU order", () => {
   const cache = new MaskedCache();
   for (let index = 0; index < MASKED_CACHE_MAX_ENTRIES; index++) {

--- a/tests/perf-mask.bench.ts
+++ b/tests/perf-mask.bench.ts
@@ -1,0 +1,91 @@
+/**
+ * tests/perf-mask.bench.ts
+ * Manual benchmark (excluded from `npm test`, which only globs *.test.ts).
+ *
+ * Run: node tests/perf-mask.bench.ts
+ *
+ * Models the per-turn cost shape of the context hook over a 200-message
+ * conversation with 50 rules: cold fill (maskValue per message), the old
+ * uncached behavior (re-run maskValue for everything every turn), and the
+ * cached path (fingerprint lookup). Reports milliseconds; no assertions, so
+ * timing noise can never fail a run.
+ */
+
+import { performance } from "node:perf_hooks";
+import { Masker } from "../masker.ts";
+import type { MaskingRule } from "../masker.ts";
+import { MaskedCache, hashMessage } from "../masked-cache.ts";
+import { transcriptKey } from "../history-viewer.ts";
+
+const KEY = Buffer.from("0123456789abcdef0123456789abcdef", "hex");
+const MESSAGE_COUNT = 200;
+
+const rules: MaskingRule[] = [
+  { id: "phone", type: "regex", pattern: "\\b\\d{3}-\\d{3}-\\d{4}\\b" },
+  ...Array.from({ length: 49 }, (_, index): MaskingRule => ({
+    id: `literal-${index}`,
+    real: `sk-service-${index}-aaaaaaaaaaaa`,
+    placeholder: `placeholder-${index}`,
+  })),
+];
+
+function buildConversation(): Array<{ role: string; content: string }> {
+  return Array.from({ length: MESSAGE_COUNT }, (_, index) => ({
+    role: index % 5 === 4 ? "assistant" : "user",
+    content:
+      `Message ${index}: key sk-service-${index % 49}-aaaaaaaaaaaa and phone ${String(100 + index).slice(0, 3)}-555-${String(100000 + index).slice(-4)}. ` +
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20),
+  }));
+}
+
+function runUncached(messages: unknown[], masker: Masker): void {
+  for (const message of messages) {
+    masker.maskValue(message, { discover: true });
+  }
+}
+
+function runCached(messages: unknown[], cache: MaskedCache): { hits: number; misses: number } {
+  let hits = 0;
+  let misses = 0;
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    const key = transcriptKey(message as Record<string, unknown>, index);
+    const hash = hashMessage(message);
+    if (cache.lookup(key, hash) !== undefined) {
+      hits++;
+      continue;
+    }
+    misses++;
+    cache.record(key, hash, hash, message);
+  }
+  return { hits, misses };
+}
+
+const messages = buildConversation();
+
+// Cold fill through the real engine (also populates dynamicMap state).
+const fillStart = performance.now();
+const engine = new Masker(rules, true, KEY);
+runUncached(messages, engine);
+const fillMs = performance.now() - fillStart;
+
+// Old behavior: re-mask everything on the next turn.
+const uncachedStart = performance.now();
+runUncached(messages, engine);
+const uncachedMs = performance.now() - uncachedStart;
+
+// Cached behavior: fingerprints only.
+const cache = new MaskedCache();
+for (let index = 0; index < messages.length; index++) {
+  const key = transcriptKey(messages[index] as Record<string, unknown>, index);
+  const hash = hashMessage(messages[index]);
+  cache.record(key, hash, hash, messages[index]);
+}
+const cachedStart = performance.now();
+const { hits } = runCached(messages, cache);
+const cachedMs = performance.now() - cachedStart;
+
+console.log(`messages=${MESSAGE_COUNT} rules=${rules.length}`);
+console.log(`cold fill:        ${fillMs.toFixed(2)} ms`);
+console.log(`uncached re-pass: ${uncachedMs.toFixed(2)} ms`);
+console.log(`cached lookups:   ${cachedMs.toFixed(2)} ms (${hits}/${messages.length} hits)`);


### PR DESCRIPTION
Fixes double masking that made every request slow.

**Problem**
On every LLM request we masked the whole conversation twice:
- `context` hook masked all messages
- `before_provider_request` masked them again as safety net

History never changes between turns, but we re-scanned it every time. With 200 messages and 50 rules this was ~22ms wasted per turn. Also `persistSnapshots` and `mergeTranscript` re-did the same work.

**Solution**
Cache the masked result per message and reuse it when the message hasn't changed.

- Added `masked-cache.ts` with `MaskedCache`. Key is message content hash (`sha256` of JSON), not object identity. If hash matches, we return cached masked value. If not, we do full `maskValue` once and store it.
- Same hash is reused to skip snapshot diff and transcript cloning for unchanged history.
- Cache is cleared when it should be: rule/caseSensitive change (`rebuild`), `/masking-toggle`, or new session (`session_start`). Clears are wholesale (5000 entries for cache, 10k for snapshot hashes) - cheap to refill.
- `before_provider_request` still always checks `system`/`prompt` (that's the safety net for injections). For `messages`, it uses the cache and only counts `intercepted` on real misses.
- System prompt is memoized separately since it's the same every request.

Provenance stays correct: we only skip the regex work on hits. The first time a message is seen we always run full masking so `protectedValues` is registered correctly.

**What changed**
- `masked-cache.ts` (new) - cache + `hashMessage`
- `index.ts` - use cache in `context` and `before_provider_request`, share hashes with snapshots/transcript, add `maskSystemPromptCached`
- `history-viewer.ts` - skip `structuredClone` when hash matches
- `history-persistence.ts` - export `textHash`
- `tests/masked-cache.test.ts` - tests for cache + determinism
- `tests/perf-mask.bench.ts` - manual bench
- `CHANGELOG.md`

**Testing**
- `npm run check` - ok
- `npm test` - 99/99 pass
- Bench with 200 msgs x 50 rules: cached ~2.4ms vs uncached ~11ms per re-pass (old flow did it twice)

Let me know if anything should be adjusted.
